### PR TITLE
Fix attrs imports

### DIFF
--- a/src/core/agents/composer.py
+++ b/src/core/agents/composer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-from attr import field
+from attrs import field
 
 from src.model import Message, Outline
 from src.runtime.actor import Actor

--- a/src/services/datastore.py
+++ b/src/services/datastore.py
@@ -4,7 +4,7 @@ import uuid
 import json
 from contextlib import suppress
 from typing import Any, Dict, Iterable
-from attr import define
+from attrs import define
 
 from kuzu import Database
 

--- a/src/services/indexes.py
+++ b/src/services/indexes.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from attr import define
-from attrs import field
+from attrs import define, field
 from meilisearch_python_sdk import AsyncClient
 from meilisearch_python_sdk.index import AsyncIndex
 


### PR DESCRIPTION
## Summary
- use `attrs` for field in Composer
- use `define` and `field` from attrs in Indexes
- use `define` from attrs in DataStore

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840961bc9608331967f2a99d7594fad