### PR TITLE
Add pytest setup and basic tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[test]
+      - name: Run tests
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,15 @@ dependencies = [
     "websockets>=15.0",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest>=8.2",
+    "pytest-asyncio>=0.23",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.setuptools]
 package-dir = {"src" = "src"}
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,47 @@
+import importlib
+import types
+import sys
+import attrs
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_runs():
+    sent = {"flag": False}
+
+    records = types.ModuleType("src.model.records")
+    @attrs.define
+    class Message:
+        content: str
+    @attrs.define
+    class Metadata:
+        pass
+    records.Message = Message
+    records.Metadata = Metadata
+    records.Content = str
+    sys.modules["src.model.records"] = records
+
+    model = types.ModuleType("src.model")
+    model.Message = Message
+    model.Metadata = Metadata
+    model.Content = str
+    model.Model = Message
+    sys.modules["src.model"] = model
+
+    dispatcher = types.ModuleType("src.core.agents.dispatcher")
+    class DummyDispatcher:
+        def load(self):
+            pass
+        def start(self):
+            pass
+        def ref(self):
+            class Ref:
+                def tell(self, env, sender=None):
+                    sent["flag"] = True
+            return Ref()
+    dispatcher.Dispatcher = DummyDispatcher
+    sys.modules["src.core.agents.dispatcher"] = dispatcher
+
+    bootstrap = importlib.import_module("src.bootstrap").bootstrap
+    await bootstrap()
+    assert sent["flag"]

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+import attrs
+import sys
+import pytest
+
+# Patch minimal model modules required by mailbox
+records = importlib.util.module_from_spec(
+    importlib.util.spec_from_loader("src.model.records", loader=None)
+)
+@attrs.define
+class Message:
+    content: str
+@attrs.define
+class Metadata:
+    pass
+records.Message = Message
+records.Metadata = Metadata
+records.Content = str
+sys.modules["src.model.records"] = records
+
+model = importlib.util.module_from_spec(
+    importlib.util.spec_from_loader("src.model", loader=None)
+)
+model.Message = Message
+model.Metadata = Metadata
+model.Content = str
+model.Model = Message
+sys.modules["src.model"] = model
+
+# Load mailbox module directly
+MAILBOX_PATH = Path(__file__).resolve().parents[1] / 'src/runtime/mailbox.py'
+spec = importlib.util.spec_from_file_location('mailbox', MAILBOX_PATH)
+mailbox_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mailbox_mod)
+Mailbox = mailbox_mod.Mailbox
+Envelope = mailbox_mod.Envelope
+
+@pytest.mark.asyncio
+async def test_mailbox_put_get():
+    box = Mailbox()
+    env = Envelope.create("user", Message("hi"))
+    await box.put(env)
+    assert not box.empty()
+    received = await box.get()
+    assert received.model.content == "hi"
+    box.task_done()
+    assert box.empty()

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+import attrs
+
+# Load serialize module without importing package __init__
+SERIALIZE_PATH = Path(__file__).resolve().parents[1] / 'src/runtime/serialize.py'
+spec = importlib.util.spec_from_file_location('serialize', SERIALIZE_PATH)
+serialize_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(serialize_mod)
+serialize = serialize_mod.serialize
+
+@attrs.define
+class Sample:
+    x: int
+    y: str
+
+
+def example(a: int, b: str):
+    """Example function.
+
+    Args:
+        a: first value
+        b: second text
+    """
+    return f"{a}-{b}"
+
+
+def test_serialize_class():
+    data = serialize(None, Sample)
+    assert data["type"] == "json_schema"
+    assert data["name"] == "Sample"
+    props = data["schema"]["properties"]
+    assert props["x"]["type"] == "integer"
+    assert props["y"]["type"] == "string"
+    assert set(data["schema"]["required"]) == {"x", "y"}
+
+
+def test_serialize_function():
+    data = serialize(None, example)
+    assert data["type"] == "function"
+    assert data["name"] == "example"
+    params = data["parameters"]
+    assert params["properties"]["a"]["type"] == "integer"
+    assert params["properties"]["b"]["type"] == "string"
+    assert set(params["required"]) == {"a", "b"}


### PR DESCRIPTION
## Summary
- add a pytest configuration and optional test dependencies
- create unit tests for serialization helpers, actor mailbox, and bootstrap
- enable CI workflow to run tests on pushes and PRs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684096815dd48331814598483ddaa9dd