### PR TITLE
Implement context building and library loading

### DIFF
--- a/src/core/resources/continuity.py
+++ b/src/core/resources/continuity.py
@@ -8,7 +8,7 @@ from monotonic import monotonic
 from datetime import timedelta
 
 from src.model.threads import Threads, Thread, ActiveThread
-from src.model.context import Context, ActiveContext, RecentContext
+from src.model.context import Context, ActiveContext, RecentContext, SemanticContext
 from src.model.records import Message, Metadata, Search, SearchHits
 from src.runtime.actor import Actor
 from src.runtime.utils import cosine_similarity, iso_to_epoch
@@ -64,7 +64,9 @@ class Continuity(Actor):
     async def get_context(self, msg: Message):
         thread = await self.resolve_thread(msg)
         context = Context(
-            active=ActiveContext(thread), recent=RecentContext(self.get_threads())
+            active=ActiveContext(thread),
+            recent=RecentContext(self.get_threads()),
+            semantic=SemanticContext(embed=msg.metadata.embedding, search=self.search),
         )
         await context.update(msg)
         return context

--- a/src/core/resources/library.py
+++ b/src/core/resources/library.py
@@ -24,6 +24,12 @@ class Library(Actor):
             self._loaded = True
 
     async def _load_modules(self):
-        for cfg in ("directions", "outlines"):
+        await self._indexes.load_indexes()
+        for cfg in ("directions", "outlines", "instructions", "tools"):
             with open(f"config/{cfg}.json", "r") as f:
-                setattr(self, cfg, json.loads(f.read()))
+                data = json.loads(f.read())
+                setattr(self, cfg, data)
+                if cfg == "tools":
+                    idx = await self._indexes.get_index("tools")
+                    records = [{"id": t.get("_sig"), **t.get("schema", {})} for t in data]
+                    await idx.update_documents(records)

--- a/src/model/context.py
+++ b/src/model/context.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
-from typing import List
+from typing import List, Callable, Awaitable
 
 from attrs import define, field
 
-from src.model.records import Message
+from src.model.records import Message, SearchHits
 from src.model.threads import Thread
 from src.runtime.utils import timestamp, iso_to_epoch
 
@@ -15,14 +15,19 @@ SEPARATOR = "\n\n---\n\n"
 
 @define
 class ActiveContext:
+    thread: Thread | None = field(default=None)
     last_n: int = field(default=4)
 
     async def build(self):
-        pass
+        if not self.thread:
+            return ""
+        body = await self.thread.build(self.last_n)
+        return "## Active Thread\n" + body
 
 
 @define
 class RecentContext:
+    threads: List[Thread] = field(factory=list)
     cutoff_sec: int = 60 * 60 * 6
 
     async def build(self):
@@ -43,11 +48,18 @@ class RecentContext:
 
 @define
 class SemanticContext:
-    embed: List[float] = []
+    embed: List[float] = field(factory=list)
     top_k: int = 6
+    search: Callable[[List[float], int], Awaitable[SearchHits]] | None = field(default=None, repr=False)
 
     async def build(self):
-        pass
+        if not self.embed or not self.search:
+            return ""
+        hits = await self.search(self.embed, self.top_k)
+        results = [h.get("content", "") for h in hits.hits]
+        if not results:
+            return ""
+        return "## Semantic Search\n" + "\n".join(results)
 
 
 @define

--- a/src/model/records.py
+++ b/src/model/records.py
@@ -92,6 +92,7 @@ class Metadata:
     annotations: List[str] = field(factory=list)
     embedding: List[float] = field(factory=list, repr=False)
     keywords: List[str] = field(factory=list)
+    events: List[Dict[str, Any]] = field(factory=list)
 
 
 __all__ = (

--- a/tests/test_library_continuity.py
+++ b/tests/test_library_continuity.py
@@ -1,0 +1,78 @@
+import asyncio
+import os
+import sys
+import types
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+if 'src' not in sys.modules:
+    pkg = types.ModuleType('src')
+    pkg.__path__ = [os.path.join(ROOT, 'src')]
+    sys.modules['src'] = pkg
+
+# stub external service modules so imports succeed
+if 'src.services' not in sys.modules:
+    services = types.ModuleType('src.services')
+    services.__path__ = []
+    sys.modules['src.services'] = services
+    indexes_mod = types.ModuleType('src.services.indexes')
+    services.indexes = indexes_mod
+    sys.modules['src.services.indexes'] = indexes_mod
+    llm_mod = types.ModuleType('src.services.llm')
+    llm_mod.completion = lambda **kwargs: None
+    llm_mod.response = lambda **kwargs: None
+    sys.modules['src.services.llm'] = llm_mod
+
+class DummyIndex:
+    def __init__(self):
+        self.updated = []
+    async def update_documents(self, docs):
+        self.updated.extend(docs)
+    def search(self, q):
+        return type('Res', (), {'hits':[{'content':'hit'}]})
+
+class DummyIndexes:
+    def __init__(self):
+        self.index = DummyIndex()
+    async def load_indexes(self):
+        pass
+    async def get_index(self, name):
+        return self.index
+
+indexes_mod.Indexes = DummyIndexes
+
+from src.core.resources.library import Library
+from src.core.resources.continuity import Continuity
+from src.model.records import Message, Metadata
+
+@pytest.mark.asyncio
+async def test_library_loads_modules_into_index():
+    idx = DummyIndexes()
+    lib = Library(indexes=idx)
+    await lib.load()
+    assert lib._directions
+    assert lib._outlines
+    assert lib._instructions
+    assert idx.index.updated
+
+@pytest.mark.asyncio
+async def test_continuity_thread_history():
+    idx = DummyIndexes()
+    cont = Continuity(indexes=idx)
+    m1 = Message(content="hello")
+    m1.metadata = Metadata(embedding=[0.1])
+    m1.metadata.events = []
+    ctx1 = await cont.get_context(m1)
+    assert len(cont.get_threads()) == 1
+
+    m2 = Message(content="world")
+    m2.metadata = Metadata(embedding=[0.1])
+    m2.metadata.events = []
+    ctx2 = await cont.get_context(m2)
+    threads = cont.get_threads()
+    assert len(threads) == 1
+    assert len(threads[0].content) == 2
+    built = await ctx2.build()
+    assert "## Active Thread" in built


### PR DESCRIPTION
## Summary
- implement tool and direction loading for Library
- flesh out ActiveContext and SemanticContext
- wire Continuity to use SemanticContext
- support thread events in Metadata
- add basic tests for Library and Continuity

## Testing
- `pytest tests/test_library_continuity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6840966218ac8331bdfa1d3c8acfd9c2