### PR TITLE
Fix actor messaging workflow

### DIFF
--- a/src/core/agents/composer.py
+++ b/src/core/agents/composer.py
@@ -30,7 +30,7 @@ class Composer(Actor):
         self.context = env.model
         outline = await self.on(env.model)
         if env.sender is not None:
-            env.sender.tell(outline, sender=self.ref())
+            env.sender.tell(Envelope(model=outline), sender=self.ref())
 
     async def execute(self, msg: Message):
         async for res in self.generate(self.context):

--- a/src/core/agents/executor.py
+++ b/src/core/agents/executor.py
@@ -19,7 +19,7 @@ class Executor(Actor):
         outline = env.model
         self._process = Process(outline=outline)
         if env.sender is not None:
-            env.sender.tell(self._process, sender=self.ref())
+            env.sender.tell(Envelope(model=self._process), sender=self.ref())
 
     async def execute(self):
         async def sink(self):

--- a/src/core/agents/interpreter.py
+++ b/src/core/agents/interpreter.py
@@ -17,9 +17,9 @@ class Interpreter(Actor):
     _workers: Dict[str, Actor] = field(factory=dict)
 
     async def on_receive(self, env: Envelope):
-        self._context = await self._continuity.get_context(env)
+        self._context = await self._continuity.get_context(env.model)
         if env.sender is not None:
-            env.sender.tell(self._context, sender=self.ref())
+            env.sender.tell(Envelope(model=self._context), sender=self.ref())
 
     async def interpret(self, env: Envelope):
         async for res in self.generate(self._context):

--- a/src/runtime/actor.py
+++ b/src/runtime/actor.py
@@ -39,7 +39,7 @@ class ActorRef:
 
 @define(slots=True)
 class Actor:
-    _mailbox: Mailbox = Mailbox()
+    _mailbox: Mailbox = field(factory=Mailbox)
     _task: Optional[asyncio.Task] = field(init=False, default=None, repr=False)
 
     def start(self):

--- a/src/runtime/mailbox.py
+++ b/src/runtime/mailbox.py
@@ -1,1 +1,43 @@
+from __future__ import annotations
 
+import asyncio
+from typing import Any
+
+from attrs import define, field
+
+
+@define(slots=True)
+class Envelope:
+    """Simple wrapper for actor messages."""
+    model: Any = field(default=None)
+    sender: str | None = field(default=None)
+    metadata: Any = field(default=None)
+    correlation: str | None = field(default=None)
+
+    @classmethod
+    def create(cls, sender: str, model: Any):
+        return cls(model=model, metadata=None, sender=sender)
+
+
+@define
+class Mailbox:
+    """Simple async message queue used by actors."""
+    _queue: asyncio.Queue = field(factory=lambda: asyncio.Queue(maxsize=24))
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    def put_nowait(self, obj: Any) -> None:
+        self._queue.put_nowait(obj)
+
+    async def put(self, obj: Any) -> None:
+        await self._queue.put(obj)
+
+    async def get(self) -> Envelope:
+        return await self._queue.get()
+
+    def task_done(self) -> None:
+        self._queue.task_done()
+
+
+__all__ = ["Mailbox", "Envelope"]

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -4,6 +4,15 @@ from contextlib import suppress
 from pathlib import Path
 import sys
 import os
+import types
+import importlib.util as iu
+import pathlib
+import sysconfig
+path = pathlib.Path(sysconfig.get_path("stdlib")) / "typing.py"
+spec = iu.spec_from_file_location("typing", path)
+_typing = iu.module_from_spec(spec)
+spec.loader.exec_module(_typing)
+sys.modules["typing"] = _typing
 
 src_path = Path(__file__).resolve().parents[1] / "src"
 sys.path.insert(0, str(src_path))
@@ -13,6 +22,25 @@ if tests_dir in sys.path:
     sys.path.remove(tests_dir)
 sys.modules.pop("typing", None)
 sys.modules.pop("socket", None)
+
+if 'src' not in sys.modules:
+    pkg = types.ModuleType('src')
+    pkg.__path__ = [str(src_path)]
+    sys.modules['src'] = pkg
+if 'src.services' not in sys.modules:
+    services = types.ModuleType('src.services')
+    services.__path__ = []
+    sys.modules['src.services'] = services
+indexes_mod = types.ModuleType('src.services.indexes')
+services.indexes = indexes_mod
+sys.modules['src.services.indexes'] = indexes_mod
+llm_mod = types.ModuleType('src.services.llm')
+llm_mod.completion = lambda **kwargs: None
+llm_mod.response = lambda **kwargs: None
+sys.modules['src.services.llm'] = llm_mod
+sys.modules['src.services.datastore'] = types.ModuleType('src.services.datastore')
+sys.modules.setdefault('src.config', types.ModuleType('src.config')).DATA = ''
+indexes_mod.Indexes = lambda: None
 
 class DummyReceiver:
     def __init__(self):
@@ -45,10 +73,18 @@ class ActorTests(unittest.IsolatedAsyncioTestCase):
     async def test_interpreter_handles_message(self):
         from src.core.agents.interpreter import Interpreter
         from src.core.resources.continuity import Continuity
-        from src.model.records import Message
+        from src.model.records import Message, Metadata
+        import attrs
+        @attrs.define(slots=True)
+        class DummyMessage(Message):
+            metadata: Metadata = attrs.field(factory=Metadata)
+
         interp = Interpreter(continuity=Continuity())
         receiver = DummyReceiver()
-        await interp.on_receive(Message(content="hello"))
+        from src.runtime.mailbox import Envelope
+        msg = DummyMessage(content="hello", metadata=Metadata(embedding=[]))
+        msg.metadata.events = []
+        await interp.on_receive(Envelope.create(None, msg))
         env = receiver.received
         self.assertIsNone(env)
 
@@ -60,7 +96,8 @@ class ActorTests(unittest.IsolatedAsyncioTestCase):
         comp = Composer(library=Library())
         comp.start()
         ctx = Context(ActiveContext(thread=Thread()), RecentContext(threads=[]))
-        comp.ref().tell(ctx)
+        from src.runtime.mailbox import Envelope
+        comp.ref().tell(Envelope.create(None, ctx))
         await asyncio.sleep(0.1)
         self.assertIn("last", comp.outlines)
         comp._task.cancel()
@@ -74,7 +111,8 @@ class ActorTests(unittest.IsolatedAsyncioTestCase):
         exe = Executor(catalog=Catalog())
         exe.start()
         out = Outline(tasks=[])
-        exe.ref().tell(out)
+        from src.runtime.mailbox import Envelope
+        exe.ref().tell(Envelope.create(None, out))
         await asyncio.sleep(0.1)
         self.assertIsNotNone(exe._process)
         exe._task.cancel()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,6 +1,14 @@
 import importlib
 import types
 import sys
+import importlib.util
+import pathlib
+import sysconfig
+path = pathlib.Path(sysconfig.get_path("stdlib")) / "typing.py"
+spec = importlib.util.spec_from_file_location("typing", path)
+_typing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(_typing)
+sys.modules["typing"] = _typing
 import attrs
 import pytest
 
@@ -19,6 +27,7 @@ async def test_bootstrap_runs():
     records.Message = Message
     records.Metadata = Metadata
     records.Content = str
+    orig_records = sys.modules.get("src.model.records")
     sys.modules["src.model.records"] = records
 
     model = types.ModuleType("src.model")
@@ -26,6 +35,7 @@ async def test_bootstrap_runs():
     model.Metadata = Metadata
     model.Content = str
     model.Model = Message
+    orig_model = sys.modules.get("src.model")
     sys.modules["src.model"] = model
 
     dispatcher = types.ModuleType("src.core.agents.dispatcher")
@@ -45,3 +55,11 @@ async def test_bootstrap_runs():
     bootstrap = importlib.import_module("src.bootstrap").bootstrap
     await bootstrap()
     assert sent["flag"]
+    if orig_model is not None:
+        sys.modules["src.model"] = orig_model
+    else:
+        sys.modules.pop("src.model", None)
+    if orig_records is not None:
+        sys.modules["src.model.records"] = orig_records
+    else:
+        sys.modules.pop("src.model.records", None)

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -1,31 +1,43 @@
 import importlib.util
 from pathlib import Path
-import attrs
 import sys
+import importlib.util as iu
+import pathlib
+import sysconfig
+path = pathlib.Path(sysconfig.get_path("stdlib")) / "typing.py"
+spec = iu.spec_from_file_location("typing", path)
+_typing = iu.module_from_spec(spec)
+spec.loader.exec_module(_typing)
+sys.modules["typing"] = _typing
+import attrs
 import pytest
 
 # Patch minimal model modules required by mailbox
-records = importlib.util.module_from_spec(
-    importlib.util.spec_from_loader("src.model.records", loader=None)
-)
+records_spec = importlib.util.spec_from_loader("src.model.records", loader=None)
+records = importlib.util.module_from_spec(records_spec)
+
 @attrs.define
 class Message:
     content: str
+
 @attrs.define
 class Metadata:
     pass
+
 records.Message = Message
 records.Metadata = Metadata
 records.Content = str
-sys.modules["src.model.records"] = records
 
-model = importlib.util.module_from_spec(
-    importlib.util.spec_from_loader("src.model", loader=None)
-)
+model_spec = importlib.util.spec_from_loader("src.model", loader=None)
+model = importlib.util.module_from_spec(model_spec)
 model.Message = Message
 model.Metadata = Metadata
 model.Content = str
 model.Model = Message
+
+_orig_model = sys.modules.get("src.model")
+_orig_records = sys.modules.get("src.model.records")
+sys.modules["src.model.records"] = records
 sys.modules["src.model"] = model
 
 # Load mailbox module directly
@@ -46,3 +58,11 @@ async def test_mailbox_put_get():
     assert received.model.content == "hi"
     box.task_done()
     assert box.empty()
+    if _orig_model is not None:
+        sys.modules["src.model"] = _orig_model
+    else:
+        sys.modules.pop("src.model", None)
+    if _orig_records is not None:
+        sys.modules["src.model.records"] = _orig_records
+    else:
+        sys.modules.pop("src.model.records", None)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,5 +1,14 @@
 import importlib.util
 from pathlib import Path
+import sys
+import importlib.util as iu
+import pathlib
+import sysconfig
+path = pathlib.Path(sysconfig.get_path("stdlib")) / "typing.py"
+spec = iu.spec_from_file_location("typing", path)
+_typing = iu.module_from_spec(spec)
+spec.loader.exec_module(_typing)
+sys.modules["typing"] = _typing
 import attrs
 
 # Load serialize module without importing package __init__


### PR DESCRIPTION
## Summary
- wire dispatcher -> interpreter -> composer -> executor
- rework Actor mailbox setup
- add minimal mailbox and envelope modules
- adjust tests for typed message flow and stub deps

## Testing
- `pytest -q` *(fails: update: unsupported type <class 'test_actors.ActorTests.test_interpreter_handles_message.<locals>.DummyMessage'>)*

------
https://chatgpt.com/codex/tasks/task_e_6840fe98f8188331906b5614f48e44fd