### PR TITLE
Add FastAPI websocket interface

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import uvicorn
-from fastapi import FastAPI
-
 from src.bootstrap import bootstrap
+from src.api import create_app
 
 
 async def main():
     await bootstrap()
     server = uvicorn.Server(
-        uvicorn.Config(app=FastAPI(), host="127.0.0.1", port=8000, log_level="info")
+        uvicorn.Config(
+            app=create_app(), host="127.0.0.1", port=8000, log_level="info"
+        )
     )
     server_task = asyncio.create_task(server.serve())
     done, pending = await asyncio.wait(

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from src.core.agents.dispatcher import Dispatcher
+from src.model.records import Message, Envelope
+from src.runtime.actor import Actor
+
+
+class WebSocketActor(Actor):
+    def __init__(self, ws: WebSocket):
+        super().__init__()
+        self._ws = ws
+
+    async def on_receive(self, env: Envelope):
+        data = env.model
+        if isinstance(data, Message):
+            content = data.content
+        else:
+            content = data
+        if isinstance(content, bytes):
+            await self._ws.send_bytes(content)
+        else:
+            await self._ws.send_text(str(content))
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    dispatcher = Dispatcher()
+
+    @app.on_event("startup")
+    async def startup_event() -> None:
+        dispatcher.load()
+        dispatcher.start()
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(ws: WebSocket):
+        await ws.accept()
+        actor = WebSocketActor(ws)
+        actor.start()
+        try:
+            while True:
+                try:
+                    message = await ws.receive()
+                except WebSocketDisconnect:
+                    break
+                if "text" in message and message["text"] is not None:
+                    msg = Message(content=message["text"])
+                elif "bytes" in message and message["bytes"] is not None:
+                    msg = Message(content=message["bytes"])
+                else:
+                    continue
+                env = Envelope.create("user", msg)
+                dispatcher.ref().tell(env, sender=actor.ref())
+        finally:
+            if actor._task:
+                actor._task.cancel()
+
+    return app

--- a/src/runtime/mailbox.py
+++ b/src/runtime/mailbox.py
@@ -1,1 +1,31 @@
+from __future__ import annotations
 
+import asyncio
+from attrs import define, field
+
+
+@define
+class Mailbox:
+    _queue: asyncio.Queue = field(factory=asyncio.Queue)
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+    async def put(self, item):
+        await self._queue.put(item)
+
+    async def get(self):
+        return await self._queue.get()
+
+    def task_done(self):
+        self._queue.task_done()
+
+
+@define
+class Envelope:
+    sender: str
+    model: object
+
+    @classmethod
+    def create(cls, sender: str, model: object):
+        return cls(sender=sender, model=model)

--- a/tests/test_actors.py
+++ b/tests/test_actors.py
@@ -6,6 +6,8 @@ import sys
 import os
 
 src_path = Path(__file__).resolve().parents[1] / "src"
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
 sys.path.insert(0, str(src_path))
 os.environ["PYTHONPATH"] = str(src_path)
 tests_dir = str(Path(__file__).resolve().parent)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,98 @@
+import sys
+import importlib
+import types
+import os
+from pathlib import Path
+
+src_path = Path(__file__).resolve().parents[1] / "src"
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo_root))
+sys.path.insert(0, str(src_path))
+os.environ["PYTHONPATH"] = str(src_path)
+tests_dir = str(Path(__file__).resolve().parent)
+if tests_dir in sys.path:
+    sys.path.remove(tests_dir)
+sys.modules.pop("typing", None)
+sys.modules.pop("socket", None)
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.asyncio
+async def test_websocket_endpoint():
+
+    import attrs
+
+    import attrs
+    saved = {}
+    def patch(name, module):
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    # Dummy records module
+    records = types.ModuleType("src.model.records")
+
+    @attrs.define
+    class Message:
+        content: object
+
+    @attrs.define
+    class Metadata:
+        pass
+
+    @attrs.define
+    class Envelope:
+        model: Message
+        sender: object | None = None
+
+        @classmethod
+        def create(cls, sender: str, model: Message):
+            return cls(model=model)
+
+    records.Message = Message
+    records.Metadata = Metadata
+    records.Envelope = Envelope
+    patch("src.model.records", records)
+
+    model = types.ModuleType("src.model")
+    model.Message = Message
+    model.Metadata = Metadata
+    model.Content = object
+    model.Model = Message
+    patch("src.model", model)
+
+    dispatcher_mod = types.ModuleType("src.core.agents.dispatcher")
+
+    class DummyDispatcher:
+        def load(self):
+            pass
+
+        def start(self):
+            pass
+
+        def ref(self):
+            class Ref:
+                def tell(self, env, sender=None):
+                    if sender is not None:
+                        sender.tell(env)
+
+            return Ref()
+
+    dispatcher_mod.Dispatcher = DummyDispatcher
+    patch("src.core.agents.dispatcher", dispatcher_mod)
+
+    print('sys.path', sys.path[:3])
+    print('modules patched')
+
+    try:
+        api = importlib.import_module("src.api")
+        app = api.create_app()
+        assert "/ws" in {r.path for r in app.router.routes}
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                del sys.modules[name]
+            else:
+                sys.modules[name] = mod
+

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,12 +1,17 @@
 import importlib
 import types
 import sys
+import os
+from pathlib import Path
 import attrs
 import pytest
 
 
 @pytest.mark.asyncio
 async def test_bootstrap_runs():
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
     sent = {"flag": False}
 
     records = types.ModuleType("src.model.records")


### PR DESCRIPTION
## Summary
- implement FastAPI websocket server in `src/api.py`
- hook new API into application startup
- add simple mailbox/Envelope implementation
- provide regression test for websocket route
- update tests to ensure repo root on `sys.path`

## Testing
- `pytest tests/test_api.py::test_websocket_endpoint -q`
- `pytest -q` *(fails: ImportError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6840fef7883c8331b27e9012013fd3e1